### PR TITLE
Add <CR> navigation in query scratch buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- `<CR>` in query scratch buffers jumps to requirement definition via LSP
+  `workspace/symbol`, populating the location list for multi-match navigation
+
 ## [0.3.0] - 2026-02-22
 
 ### Changed

--- a/doc/tracey.txt
+++ b/doc/tracey.txt
@@ -122,6 +122,9 @@ Subcommands ~
                   Uses `web_port` from config if set (see |tracey.Config|).
 
 Query results open in a read-only scratch buffer. Press `q` to close.
+Press `<CR>` on a requirement line to jump to its definition via the LSP.
+Results are placed in the location list, so |:lnext| and |:lprev| navigate
+between multiple matches.
 
 Tab completion is supported for all subcommands.
 

--- a/lua/tracey/config.lua
+++ b/lua/tracey/config.lua
@@ -9,7 +9,13 @@ local M = {}
 ---@field on_attach? fun(client: vim.lsp.Client, bufnr: integer) Callback on attach
 ---@field exit_timeout? integer|false Timeout in ms before SIGTERM on exit (default 500, false to disable)
 ---@field web_port? integer Port for `tracey web` (omitted if nil, letting tracey choose)
+---@field query_layout? tracey.QueryLayout|fun(title: string, line_count: integer): tracey.QueryLayout? Layout options for query scratch buffers
 ---@field lsp? table Escape hatch: passed verbatim to vim.lsp.config()
+
+---@class tracey.QueryLayout
+---@field split? string Vim command to create the split (default "botright new")
+---@field height? integer Window height after creation
+---@field width? integer Window width after creation
 
 ---@type tracey.Config
 local defaults = {

--- a/tests/tracey_spec.lua
+++ b/tests/tracey_spec.lua
@@ -101,6 +101,27 @@ do
 end
 
 -- ============================================================================
+-- CLI parse_requirement_id tests
+-- ============================================================================
+io.write('\n--- CLI parse_requirement_id ---\n')
+
+do
+  local cli = require('tracey.cli')
+
+  -- Valid requirement lines
+  assert_eq(cli._parse_requirement_id('  - auth.login'), 'auth.login', 'parses simple requirement ID')
+  assert_eq(cli._parse_requirement_id('  - todo.validation.title'), 'todo.validation.title', 'parses dotted requirement ID')
+  assert_eq(cli._parse_requirement_id('  - a'), 'a', 'parses single-char requirement ID')
+
+  -- Non-matching lines
+  assert_eq(cli._parse_requirement_id('# Heading'), nil, 'heading does not match')
+  assert_eq(cli._parse_requirement_id(''), nil, 'empty line does not match')
+  assert_eq(cli._parse_requirement_id('Summary: 5 rules'), nil, 'summary line does not match')
+  assert_eq(cli._parse_requirement_id('- auth.login'), nil, 'wrong indentation does not match')
+  assert_eq(cli._parse_requirement_id('    - auth.login'), nil, 'four-space indent does not match')
+end
+
+-- ============================================================================
 -- Summary
 -- ============================================================================
 io.write(string.format('\n=== %d passed, %d failed ===\n', pass, fail))


### PR DESCRIPTION
## Summary

- Press `<CR>` on a requirement line (e.g. `  - auth.login`) in query scratch buffers to jump to its definition via LSP `workspace/symbol`
- Results populate the location list, so `:lnext` / `:lprev` navigate between multiple matches
- Adds `parse_requirement_id` with tests for matching/non-matching line formats

## Test plan

- [x] Run `nvim --headless -u NONE --cmd "set rtp+=." -c "lua dofile('tests/tracey_spec.lua')" -c "qall!"` — 25 tests pass
- [x] Open a project with tracey LSP running, run `:Tracey untested`, cursor to a requirement line, press `<CR>` — verify location list is populated and cursor jumps to spec definition
- [x] Verify `<CR>` on non-requirement lines (headings, summary) is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)