### PR TITLE
Add :Tracey quickfix subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 - `<CR>` in query scratch buffers jumps to requirement definition via LSP
   `workspace/symbol`, populating the location list for multi-match navigation
+- `:Tracey quickfix <filter>` subcommand to populate the quickfix list with
+  resolved file:line locations for `uncovered`, `untested`, or `stale` requirements
 
 ## [0.3.0] - 2026-02-22
 

--- a/doc/tracey.txt
+++ b/doc/tracey.txt
@@ -120,6 +120,9 @@ Subcommands ~
   `stale`         Run `tracey query stale` to list stale references.
   `web`           Start the tracey web dashboard in the background.
                   Uses `web_port` from config if set (see |tracey.Config|).
+  `quickfix`      Populate the quickfix list with file locations for
+                  requirements matching a filter. Requires a second argument:
+                  `uncovered`, `untested`, or `stale`. See |:Tracey-quickfix|.
 
 Query results open in a read-only scratch buffer. Press `q` to close.
 Press `<CR>` on a requirement line to jump to its definition via the LSP.
@@ -127,6 +130,23 @@ Results are placed in the location list, so |:lnext| and |:lprev| navigate
 between multiple matches.
 
 Tab completion is supported for all subcommands.
+
+                                                         *:Tracey-quickfix*
+:Tracey quickfix {filter}
+
+  Resolve all requirement IDs from the given query to file:line locations
+  and populate the quickfix list. Use |:cnext| / |:cprev| to navigate.
+
+  {filter} is required and must be one of:
+    `uncovered`   Requirements without implementation references.
+    `untested`    Requirements without verification references.
+    `stale`       Requirements with stale references.
+
+  Examples: >
+    :Tracey quickfix uncovered
+    :Tracey quickfix untested
+    :Tracey quickfix stale
+<
 
 ==============================================================================
 6. LUA API                                                    *tracey-api*

--- a/lua/tracey/cli.lua
+++ b/lua/tracey/cli.lua
@@ -140,6 +140,121 @@ function M.query(subcmd)
   end))
 end
 
+--- Extract all requirement IDs from query output lines.
+---@param lines string[]
+---@return string[]
+local function parse_all_requirement_ids(lines)
+  local ids = {}
+  for _, line in ipairs(lines) do
+    local id = parse_requirement_id(line)
+    if id then
+      table.insert(ids, id)
+    end
+  end
+  return ids
+end
+M._parse_all_requirement_ids = parse_all_requirement_ids
+
+--- Parse locations from `tracey query rule` output.
+--- Matches "Defined in: <file>:<line>" and "  - <file>:<line>" patterns.
+---@param rule_output string
+---@param root string|nil  Project root for resolving relative paths
+---@return {filename: string, lnum: integer}[]
+local function parse_rule_locations(rule_output, root)
+  local entries = {}
+  for line in rule_output:gmatch('[^\n]+') do
+    -- Match "Defined in: path/to/file.rs:42"
+    local file, lnum = line:match('^Defined in: (.+):(%d+)$')
+    if not file then
+      -- Match "  - path/to/file.rs:42"
+      file, lnum = line:match('^  %- (.+):(%d+)$')
+    end
+    if file and lnum then
+      if root and not file:match('^/') then
+        file = root .. '/' .. file
+      end
+      table.insert(entries, { filename = file, lnum = tonumber(lnum) })
+    end
+  end
+  return entries
+end
+M._parse_rule_locations = parse_rule_locations
+
+--- Run a tracey query and populate the quickfix list with resolved locations.
+---@param subcmd string  One of "uncovered", "untested", "stale"
+function M.query_quickfix(subcmd)
+  local root = M.find_root()
+  local cmd = { 'tracey', 'query' }
+  if root then
+    table.insert(cmd, root)
+  end
+  table.insert(cmd, subcmd)
+
+  vim.notify('tracey: running quickfix query ' .. subcmd .. '...', vim.log.levels.INFO)
+
+  vim.system(cmd, { text = true }, vim.schedule_wrap(function(result)
+    if result.code ~= 0 then
+      local msg = result.stderr and vim.trim(result.stderr) or ('exit code ' .. result.code)
+      vim.notify('tracey quickfix ' .. subcmd .. ': ' .. msg, vim.log.levels.ERROR)
+      return
+    end
+
+    local output = result.stdout or ''
+    local lines = vim.split(output, '\n', { trimempty = true })
+    local ids = parse_all_requirement_ids(lines)
+
+    if #ids == 0 then
+      vim.notify('tracey quickfix ' .. subcmd .. ': no requirements found', vim.log.levels.INFO)
+      return
+    end
+
+    local all_entries = {}
+    local pending = #ids
+    local failures = 0
+
+    for _, id in ipairs(ids) do
+      local rule_cmd = { 'tracey', 'query' }
+      if root then
+        table.insert(rule_cmd, root)
+      end
+      table.insert(rule_cmd, 'rule')
+      table.insert(rule_cmd, id)
+
+      vim.system(rule_cmd, { text = true }, vim.schedule_wrap(function(rule_result)
+        if rule_result.code ~= 0 then
+          failures = failures + 1
+        else
+          local rule_output = rule_result.stdout or ''
+          local entries = parse_rule_locations(rule_output, root)
+          for _, entry in ipairs(entries) do
+            entry.text = id
+            table.insert(all_entries, entry)
+          end
+        end
+
+        pending = pending - 1
+        if pending == 0 then
+          table.sort(all_entries, function(a, b)
+            if a.filename ~= b.filename then
+              return a.filename < b.filename
+            end
+            return a.lnum < b.lnum
+          end)
+
+          vim.fn.setqflist(all_entries, 'r')
+          vim.cmd('copen')
+
+          local msg = string.format('tracey quickfix %s: %d entries', subcmd, #all_entries)
+          if failures > 0 then
+            msg = msg .. string.format(' (%d lookups failed)', failures)
+          end
+          vim.notify(msg, vim.log.levels.INFO)
+        end
+      end))
+    end
+  end))
+end
+
 --- Start the tracey web dashboard as a background job.
 function M.web()
   if M._web_job then

--- a/lua/tracey/cli.lua
+++ b/lua/tracey/cli.lua
@@ -155,8 +155,9 @@ local function parse_all_requirement_ids(lines)
 end
 M._parse_all_requirement_ids = parse_all_requirement_ids
 
---- Parse locations from `tracey query rule` output.
---- Matches "Defined in: <file>:<line>" and "  - <file>:<line>" patterns.
+--- Parse the definition location from `tracey query rule` output.
+--- Matches only "Defined in: <file>:<line>" (the spec item itself),
+--- ignoring implementation references listed under "References:".
 ---@param rule_output string
 ---@param root string|nil  Project root for resolving relative paths
 ---@return {filename: string, lnum: integer}[]
@@ -165,10 +166,6 @@ local function parse_rule_locations(rule_output, root)
   for line in rule_output:gmatch('[^\n]+') do
     -- Match "Defined in: path/to/file.rs:42"
     local file, lnum = line:match('^Defined in: (.+):(%d+)$')
-    if not file then
-      -- Match "  - path/to/file.rs:42"
-      file, lnum = line:match('^  %- (.+):(%d+)$')
-    end
     if file and lnum then
       if root and not file:match('^/') then
         file = root .. '/' .. file

--- a/plugin/tracey.lua
+++ b/plugin/tracey.lua
@@ -6,7 +6,7 @@ vim.g.loaded_tracey = true
 vim.api.nvim_create_user_command('Tracey', function(args)
   require('tracey.commands').run(args)
 end, {
-  nargs = '?',
+  nargs = '*',
   complete = function(arg_lead, cmdline, cursor_pos)
     return require('tracey.commands').complete(arg_lead, cmdline, cursor_pos)
   end,

--- a/tests/tracey_spec.lua
+++ b/tests/tracey_spec.lua
@@ -160,7 +160,7 @@ io.write('\n--- CLI parse_rule_locations ---\n')
 do
   local cli = require('tracey.cli')
 
-  -- Basic output with "Defined in:" and list entries
+  -- Only "Defined in:" lines are extracted; implementation references are ignored
   local output = table.concat({
     'Rule: auth.login',
     'Defined in: spec/auth.md:10',
@@ -169,12 +169,9 @@ do
     '  - src/auth.rs:100',
   }, '\n')
   local entries = cli._parse_rule_locations(output, '/project')
-  assert_eq(#entries, 3, 'parses all location lines')
+  assert_eq(#entries, 1, 'parses only the Defined in line')
   assert_eq(entries[1].filename, '/project/spec/auth.md', 'resolves relative path for Defined in')
   assert_eq(entries[1].lnum, 10, 'parses line number for Defined in')
-  assert_eq(entries[2].filename, '/project/src/auth.rs', 'resolves relative path for list entry')
-  assert_eq(entries[2].lnum, 42, 'parses line number for list entry')
-  assert_eq(entries[3].lnum, 100, 'parses second list entry line number')
 
   -- Absolute paths should not be prefixed
   local abs_output = 'Defined in: /absolute/path/file.rs:5'


### PR DESCRIPTION
## Summary

- Adds `:Tracey quickfix <filter>` subcommand (`uncovered`, `untested`, or `stale`)
- Resolves all requirement IDs from the chosen query to file:line locations via `tracey query rule`, runs lookups concurrently
- Populates the quickfix list for navigation with `:cnext` / `:cprev`
- Tab completion supports the two-argument form (`:Tracey quickfix <Tab>`)
- Changes `nargs` from `?` to `*` to support multi-argument commands

Stacked on #4.

## Test plan

- [x] Run `nvim --headless -u NONE --cmd "set rtp+=." -c "lua dofile('tests/tracey_spec.lua')" -c "qall!"` — 39 tests pass
- [x] In a project with tracey: `:Tracey quickfix untested` — verify quickfix window opens with file:line entries
- [x] Verify `:cnext` / `:cprev` navigate between entries
- [x] Verify `:Tracey quickfix` without a filter shows an error
- [x] Verify tab completion: `:Tracey quickfix <Tab>` offers `uncovered`, `untested`, `stale`

🤖 Generated with [Claude Code](https://claude.com/claude-code)