### PR TITLE
Add eager config option to pre-launch LSP daemon at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- `eager` config option (default `true`) to pre-launch the tracey daemon at
+  startup. Searches upward from cwd for `.config/tracey/config.styx` and runs
+  `tracey daemon` so the index is warm when the LSP connects (#6)
+
 ### Changed
 - Use `tracey query --json` for quickfix queries instead of parsing text output
 - Use batched `tracey query rule id1 id2 ...` for quickfix population instead
   of spawning one subprocess per requirement
 
 ### Fixed
+- Fix `exit_timeout = false` being swallowed by Lua truthiness check
 - Fix tests hanging on success in fish shell (explicit `qall!` from Lua)
 
 ## [0.5.0] - 2026-02-22

--- a/doc/tracey.txt
+++ b/doc/tracey.txt
@@ -61,7 +61,7 @@ optional.
 >lua
   require('tracey').setup({
     enable = true,            -- call vim.lsp.enable('tracey') (default: true)
-    eager = false,            -- pre-start daemon at startup (default: false)
+    eager = true,             -- pre-start daemon at startup (default: true)
     cmd = { 'tracey', 'lsp' },  -- LSP server command
     filetypes = { 'rust', 'markdown' }, -- filetypes to attach to
     root_dir = function(bufnr, cb)  -- root directory override
@@ -93,7 +93,7 @@ Fields ~
                             The daemon indexes the project in the background so
                             `tracey lsp` connects instantly when a Rust file is
                             opened. Best-effort: silently ignored on failure.
-                            Requires `enable`. Default: `false`
+                            Requires `enable`. Default: `true`
   `cmd`           string[]  LSP server command override.
   `filetypes`     string[]  Filetype override for LSP attachment.
   `root_dir`      function  Root directory override. Receives `(bufnr, cb)`;

--- a/doc/tracey.txt
+++ b/doc/tracey.txt
@@ -61,7 +61,7 @@ optional.
 >lua
   require('tracey').setup({
     enable = true,            -- call vim.lsp.enable('tracey') (default: true)
-    eager = false,            -- pre-launch daemon at startup (default: false)
+    eager = false,            -- pre-start daemon at startup (default: false)
     cmd = { 'tracey', 'lsp' },  -- LSP server command
     filetypes = { 'rust', 'markdown' }, -- filetypes to attach to
     root_dir = function(bufnr, cb)  -- root directory override
@@ -89,9 +89,10 @@ Fields ~
   `enable`        boolean   Whether setup() calls vim.lsp.enable('tracey').
                             Default: `true`
   `eager`         boolean   Search for `.config/tracey/config.styx` from cwd
-                            at startup and pre-launch the LSP server if found.
-                            Reduces delay when first opening a Rust file.
-                            Best-effort: silently ignored on failure.
+                            at startup and pre-start the tracey daemon if found.
+                            The daemon indexes the project in the background so
+                            `tracey lsp` connects instantly when a Rust file is
+                            opened. Best-effort: silently ignored on failure.
                             Requires `enable`. Default: `false`
   `cmd`           string[]  LSP server command override.
   `filetypes`     string[]  Filetype override for LSP attachment.

--- a/doc/tracey.txt
+++ b/doc/tracey.txt
@@ -61,6 +61,7 @@ optional.
 >lua
   require('tracey').setup({
     enable = true,            -- call vim.lsp.enable('tracey') (default: true)
+    eager = false,            -- pre-launch daemon at startup (default: false)
     cmd = { 'tracey', 'lsp' },  -- LSP server command
     filetypes = { 'rust', 'markdown' }, -- filetypes to attach to
     root_dir = function(bufnr, cb)  -- root directory override
@@ -87,6 +88,11 @@ Fields ~
 
   `enable`        boolean   Whether setup() calls vim.lsp.enable('tracey').
                             Default: `true`
+  `eager`         boolean   Search for `.config/tracey/config.styx` from cwd
+                            at startup and pre-launch the LSP server if found.
+                            Reduces delay when first opening a Rust file.
+                            Best-effort: silently ignored on failure.
+                            Requires `enable`. Default: `false`
   `cmd`           string[]  LSP server command override.
   `filetypes`     string[]  Filetype override for LSP attachment.
   `root_dir`      function  Root directory override. Receives `(bufnr, cb)`;

--- a/lua/tracey/config.lua
+++ b/lua/tracey/config.lua
@@ -11,7 +11,7 @@ local M = {}
 ---@field web_port? integer Port for `tracey web` (omitted if nil, letting tracey choose)
 ---@field query_layout? tracey.QueryLayout|fun(title: string, line_count: integer): tracey.QueryLayout? Layout options for query scratch buffers
 ---@field open_quickfix? fun() Called after populating the quickfix list (default: vim.cmd('copen'))
----@field eager? boolean Eagerly search for config.styx at startup and pre-start the tracey daemon so it's warm when the LSP connects (default false)
+---@field eager? boolean Eagerly search for config.styx at startup and pre-start the tracey daemon so it's warm when the LSP connects (default true)
 ---@field lsp? table Escape hatch: passed verbatim to vim.lsp.config()
 
 ---@class tracey.QueryLayout
@@ -22,6 +22,7 @@ local M = {}
 ---@type tracey.Config
 local defaults = {
   enable = true,
+  eager = true,
 }
 
 ---@type tracey.Config

--- a/lua/tracey/config.lua
+++ b/lua/tracey/config.lua
@@ -11,7 +11,7 @@ local M = {}
 ---@field web_port? integer Port for `tracey web` (omitted if nil, letting tracey choose)
 ---@field query_layout? tracey.QueryLayout|fun(title: string, line_count: integer): tracey.QueryLayout? Layout options for query scratch buffers
 ---@field open_quickfix? fun() Called after populating the quickfix list (default: vim.cmd('copen'))
----@field eager? boolean Eagerly search for config.styx at startup and pre-launch the daemon (default false)
+---@field eager? boolean Eagerly search for config.styx at startup and pre-start the tracey daemon so it's warm when the LSP connects (default false)
 ---@field lsp? table Escape hatch: passed verbatim to vim.lsp.config()
 
 ---@class tracey.QueryLayout

--- a/lua/tracey/config.lua
+++ b/lua/tracey/config.lua
@@ -11,6 +11,7 @@ local M = {}
 ---@field web_port? integer Port for `tracey web` (omitted if nil, letting tracey choose)
 ---@field query_layout? tracey.QueryLayout|fun(title: string, line_count: integer): tracey.QueryLayout? Layout options for query scratch buffers
 ---@field open_quickfix? fun() Called after populating the quickfix list (default: vim.cmd('copen'))
+---@field eager? boolean Eagerly search for config.styx at startup and pre-launch the daemon (default false)
 ---@field lsp? table Escape hatch: passed verbatim to vim.lsp.config()
 
 ---@class tracey.QueryLayout

--- a/lua/tracey/init.lua
+++ b/lua/tracey/init.lua
@@ -12,6 +12,12 @@ local function eager_start(cfg)
     table.insert(dirs, dir)
   end
 
+  -- cfg.exit_timeout can be false (disable), so a plain `or` would swallow it
+  local exit_timeout = 500
+  if cfg.exit_timeout ~= nil then
+    exit_timeout = cfg.exit_timeout
+  end
+
   local function check(i)
     if i > #dirs then return end
     vim.uv.fs_stat(dirs[i] .. '/' .. marker, function(_, stat)
@@ -21,7 +27,7 @@ local function eager_start(cfg)
             name = 'tracey',
             cmd = cfg.cmd or { 'tracey', 'lsp' },
             root_dir = dirs[i],
-            exit_timeout = (cfg.exit_timeout ~= nil) and cfg.exit_timeout or 500,
+            exit_timeout = exit_timeout,
           })
         end)
       else

--- a/tests/tracey_spec.lua
+++ b/tests/tracey_spec.lua
@@ -40,7 +40,7 @@ do
   config.set()
   local defaults = config.get()
   assert_eq(defaults.enable, true, 'default enable is true')
-  assert_eq(defaults.eager, nil, 'default eager is nil')
+  assert_eq(defaults.eager, true, 'default eager is true')
   assert_eq(defaults.cmd, nil, 'default cmd is nil')
   assert_eq(defaults.filetypes, nil, 'default filetypes is nil')
 

--- a/tests/tracey_spec.lua
+++ b/tests/tracey_spec.lua
@@ -40,6 +40,7 @@ do
   config.set()
   local defaults = config.get()
   assert_eq(defaults.enable, true, 'default enable is true')
+  assert_eq(defaults.eager, nil, 'default eager is nil')
   assert_eq(defaults.cmd, nil, 'default cmd is nil')
   assert_eq(defaults.filetypes, nil, 'default filetypes is nil')
 


### PR DESCRIPTION
When `eager = true` is set in the config, setup() asynchronously walks
parent directories from cwd looking for .config/tracey/config.styx using
non-blocking vim.uv.fs_stat callbacks. If found, the tracey LSP server
is pre-launched via vim.lsp.start() so it's already warm when a Rust or
Markdown file is opened. Best-effort: silently ignored on any failure.

Closes #6

https://claude.ai/code/session_01V4XNsv2itWybrS92QBm3LC